### PR TITLE
feat: split atlas into produto and producao

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -50,8 +50,14 @@ jobs:
         TF_VAR_atlas_org_id: ${{ secrets.MONGO_DB_ATLAS_ORG_ID }}
         TF_VAR_atlas_public_key: ${{ secrets.MONGO_DB_ATLAS_PUBLICKEY }}
         TF_VAR_atlas_private_key: ${{ secrets.MONGO_DB_ATLAS_PRIVATEKEY }}
-        TF_VAR_atlas_dbuser_name: ${{ vars.DATABASE_USER }}
-        TF_VAR_atlas_dbuser_password: ${{ secrets.DATABASE_PASS }}
+
+        TF_VAR_atlas_producao_db: ${{ vars.PRODUCAO_DATABASE_NAME }}
+        TF_VAR_atlas_producao_dbuser_name: ${{ vars.PRODUCAO_DB_USER }}
+        TF_VAR_atlas_producao_dbuser_password: ${{ secrets.PRODUCAO_DB_PASSWORD }}
+
+        TF_VAR_atlas_pedido_db: ${{ vars.PEDIDO_DATABASE_NAME }}
+        TF_VAR_atlas_pedido_dbuser_name: ${{ vars.PEDIDO_DB_USER }}
+        TF_VAR_atlas_pedido_dbuser_password: ${{ secrets.PEDIDO_DB_PASSWORD }}
 
         TF_VAR_pagamento_dbuser: ${{ vars.PAGAMENTO_DB_USER }}
         TF_VAR_pagamento_dbpassword: ${{ secrets.PAGAMENTO_DB_PASSWORD }}
@@ -67,8 +73,14 @@ jobs:
         TF_VAR_atlas_org_id: ${{ secrets.MONGO_DB_ATLAS_ORG_ID }}
         TF_VAR_atlas_public_key: ${{ secrets.MONGO_DB_ATLAS_PUBLICKEY }}
         TF_VAR_atlas_private_key: ${{ secrets.MONGO_DB_ATLAS_PRIVATEKEY }}
-        TF_VAR_atlas_dbuser_name: ${{ vars.DATABASE_USER }}
-        TF_VAR_atlas_dbuser_password: ${{ secrets.DATABASE_PASS }}
+
+        TF_VAR_atlas_producao_db: ${{ vars.PRODUCAO_DATABASE_NAME }}
+        TF_VAR_atlas_producao_dbuser_name: ${{ vars.PRODUCAO_DB_USER }}
+        TF_VAR_atlas_producao_dbuser_password: ${{ secrets.PRODUCAO_DB_PASSWORD }}
+
+        TF_VAR_atlas_pedido_db: ${{ vars.PEDIDO_DATABASE_NAME }}
+        TF_VAR_atlas_pedido_dbuser_name: ${{ vars.PEDIDO_DB_USER }}
+        TF_VAR_atlas_pedido_dbuser_password: ${{ secrets.PEDIDO_DB_PASSWORD }}
 
         TF_VAR_pagamento_dbuser: ${{ vars.PAGAMENTO_DB_USER }}
         TF_VAR_pagamento_dbpassword: ${{ secrets.PAGAMENTO_DB_PASSWORD }}

--- a/IaC/mongodb_atlas_db.tf
+++ b/IaC/mongodb_atlas_db.tf
@@ -60,10 +60,6 @@ resource "mongodbatlas_project_ip_access_list" "ip" {
   comment    = "allow all"
 }
 
-output "connection_strings" {
+output "atlas_db_address" {
   value = mongodbatlas_advanced_cluster.cluster.connection_strings[0].standard_srv
-}
-
-output "project_name" {
-  value = mongodbatlas_project.project.name
 }

--- a/IaC/mongodb_atlas_db.tf
+++ b/IaC/mongodb_atlas_db.tf
@@ -1,5 +1,5 @@
 resource "mongodbatlas_project" "project" {
-  name   = "dotlanches-database"
+  name   = "dotlanches-databases"
   org_id = var.atlas_org_id
 }
 
@@ -11,10 +11,10 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
   replication_specs {
     region_configs {
-      priority      = 7
-      provider_name = "TENANT"
+      priority              = 7
+      provider_name         = "TENANT"
       backing_provider_name = "AWS"
-      region_name   = "US_EAST_1"
+      region_name           = "US_EAST_1"
       electable_specs {
         instance_size = "M0"
       }
@@ -22,19 +22,35 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
   }
 }
 
-resource "mongodbatlas_database_user" "user" {
-  username           = var.atlas_dbuser_name
-  password           = var.atlas_dbuser_password
+resource "mongodbatlas_database_user" "user_producao" {
+  username           = var.atlas_producao_dbuser_name
+  password           = var.atlas_producao_dbuser_password
   project_id         = mongodbatlas_project.project.id
   auth_database_name = "admin"
 
   roles {
     role_name     = "readWrite"
-    database_name = "dotlanche"
+    database_name = var.atlas_producao_db
   }
   labels {
     key   = "Name"
-    value = "dotlanches-api"
+    value = "dotlanches-producao-db"
+  }
+}
+
+resource "mongodbatlas_database_user" "user_pedido" {
+  username           = var.atlas_pedido_dbuser_name
+  password           = var.atlas_pedido_dbuser_password
+  project_id         = mongodbatlas_project.project.id
+  auth_database_name = "admin"
+
+  roles {
+    role_name     = "readWrite"
+    database_name = var.atlas_pedido_db
+  }
+  labels {
+    key   = "Name"
+    value = "dotlanches-pedido-db"
   }
 }
 

--- a/IaC/variables.tf
+++ b/IaC/variables.tf
@@ -2,26 +2,45 @@
 
 variable "atlas_public_key" {
   type        = string
-  sensitive = true
+  sensitive   = true
   description = "Public Programmatic API key to authenticate to Atlas"
 }
 variable "atlas_private_key" {
   type        = string
-  sensitive = true
+  sensitive   = true
   description = "Private Programmatic API key to authenticate to Atlas"
 }
 variable "atlas_org_id" {
   type        = string
   description = "MongoDB Organization ID"
 }
-variable "atlas_dbuser_name" {
+variable "atlas_producao_db" {
   type        = string
-  description = "MongoDB Atlas Database User Name"
+  description = "MongoDB Atlas Producao Database name"
 }
-variable "atlas_dbuser_password" {
+variable "atlas_producao_dbuser_name" {
   type        = string
-  sensitive = true
-  description = "MongoDB Atlas Database User Password"
+  description = "MongoDB Atlas Producao API Database User Name"
+}
+variable "atlas_producao_dbuser_password" {
+  type        = string
+  sensitive   = true
+  description = "MongoDB Atlas Producao API Database User Password"
+}
+
+variable "atlas_pedido_db" {
+  type        = string
+  description = "MongoDB Atlas Pedido Database name"
+}
+
+variable "atlas_pedido_dbuser_name" {
+  type        = string
+  description = "MongoDB Atlas Pedido API Database User Name"
+}
+variable "atlas_pedido_dbuser_password" {
+  type        = string
+  sensitive   = true
+  description = "MongoDB Atlas Pedido API Database User Password"
 }
 
 # AWS RDS Potgresql
@@ -31,7 +50,7 @@ variable "pagamento_dbuser" {
 }
 variable "pagamento_dbpassword" {
   type        = string
-  sensitive = true
+  sensitive   = true
   description = "AWS RDS Pagamento Database Password"
 }
 
@@ -41,6 +60,6 @@ variable "produto_dbuser" {
 }
 variable "produto_dbpassword" {
   type        = string
-  sensitive = true
+  sensitive   = true
   description = "AWS RDS Produto Database Password"
 }


### PR DESCRIPTION
Adiciona duas conexões para o mongodb atlas: uma para o serviço de pedidos e outra para o serviço de produção